### PR TITLE
Add Scrollbars to Most Windows & Check-boxes to Toggle Options

### DIFF
--- a/main.py
+++ b/main.py
@@ -37,6 +37,7 @@ FRESH_APP_CONFIG = {
     'max_lines': 40,
     'scroll_amount': 8,
     'toggle_base_file': True,
+    'prompt_save_on_exit':True,
     'immediate_identifier': '$',
     'hex_mode': False,
     'bin_mode': False,
@@ -1782,7 +1783,7 @@ def destroy_them(not_main=False):
 
 
 def close_window(side = 'right'):
-    if not disassembler_loaded():
+    if (not app_config['prompt_save_on_exit'] or not disassembler_loaded()):
         destroy_them()
         return
 
@@ -1919,6 +1920,7 @@ def open_files(mode = ''):
             app_config['game_address_mode'][disasm.hack_file_name] = False
         disasm.game_address_mode = app_config['game_address_mode'][disasm.hack_file_name]
         disasm.immediate_identifier = app_config['immediate_identifier']
+        updateToggleAddressLabel()
 
     except Exception as e:
         simpledialog.messagebox._show('Error', e)
@@ -2095,6 +2097,25 @@ def remap_jumps():
 #     remap_win.resizable(False, False)
 #     remap_win.mainloop()
 
+def toggle_save_prompt():
+    app_config["prompt_save_on_exit"] = not app_config["prompt_save_on_exit"]
+    save_config()
+    updateSavePromptLabel()
+
+def updateToggleAddressLabel(noValue = False): 
+    opts_menu.entryconfigure(6, label='Toggle "game entry point" mode (F5) {0}'.format('' if noValue else ('☑' if disasm.game_address_mode else '☐')))
+
+def updateToggleHexLabel():
+    opts_menu.entryconfigure(7, label='Toggle hex mode (F6) {0}'.format('☑' if app_config['hex_mode'] else '☐'))
+
+def updateToggleBinLabel():
+    opts_menu.entryconfigure(9, label='Toggle bin mode (F8) {0}'.format('☑' if app_config['bin_mode'] else '☐'))
+
+def updateToggleHexSpaceLabel():
+    opts_menu.entryconfigure(8, label='Toggle hex/bin space separation (F7) {0}'.format('☑' if app_config['hex_space_separation'] else '☐'))
+
+def updateSavePromptLabel():
+    opts_menu.entryconfigure(11, label='Prompt Save on Exit? {0}'.format('☑' if app_config["prompt_save_on_exit"] else '☐'))
 
 def toggle_address_mode(buffering=True):
     global function_select
@@ -2110,6 +2131,7 @@ def toggle_address_mode(buffering=True):
     # This causes bugs, have it only save when user saves
     # app_config['game_address_mode'][disasm.hack_file_name] = toggle_to
     # save_config()
+    updateToggleAddressLabel()
     navigate_to(navigation)
     hack_file_text_box.mark_set(tk.INSERT, cursor)
     highlight_stuff(skip_moving_cursor=True)
@@ -2194,6 +2216,8 @@ def toggle_hex_mode(buffering=True):
     if app_config['hex_mode']:
         app_config['bin_mode'] = False
     save_config()
+    updateToggleHexLabel()
+    updateToggleBinLabel()
     navigate_to(navigation)
     hack_file_text_box.mark_set(tk.INSERT, modify_cursor(cursor, 0, 'max', get_text_content(hack_file_text_box))[0])
     highlight_stuff(skip_moving_cursor=True)
@@ -2209,6 +2233,8 @@ def toggle_bin_mode(buffering=True):
     if app_config['bin_mode']:
         app_config['hex_mode'] = False
     save_config()
+    updateToggleHexLabel()
+    updateToggleBinLabel()
     navigate_to(navigation)
     hack_file_text_box.mark_set(tk.INSERT, modify_cursor(cursor, 0, 'max', get_text_content(hack_file_text_box))[0])
     highlight_stuff(skip_moving_cursor=True)
@@ -2218,6 +2244,7 @@ def toggle_hex_space():
     cursor, line, column = get_cursor(hack_file_text_box)
     app_config['hex_space_separation'] = not app_config['hex_space_separation']
     save_config()
+    updateToggleHexSpaceLabel()
     navigate_to(navigation)
     hack_file_text_box.mark_set(tk.INSERT, cursor)
     highlight_stuff(skip_moving_cursor=True)
@@ -4380,10 +4407,17 @@ opts_menu.add_separator()
 opts_menu.add_command(label='Set memory editor offset', command=set_mem_edit_offset)
 opts_menu.add_command(label='Set memory regions', command=set_memory_regions)
 opts_menu.add_separator()
-opts_menu.add_command(label='Toggle "game entry point" mode (F5)', command=toggle_address_mode)
-opts_menu.add_command(label='Toggle hex mode (F6)', command=toggle_hex_mode)
-opts_menu.add_command(label='Toggle hex/bin space separation (F7)', command=toggle_hex_space)
-opts_menu.add_command(label='Toggle bin mode (F8)', command=toggle_bin_mode)
+opts_menu.add_command(label='', command=toggle_address_mode)
+updateToggleAddressLabel(True)
+opts_menu.add_command(label='', command=toggle_hex_mode)
+updateToggleHexLabel()
+opts_menu.add_command(label='', command=toggle_hex_space)
+updateToggleHexSpaceLabel()
+opts_menu.add_command(label='', command=toggle_bin_mode)
+updateToggleBinLabel()
+opts_menu.add_separator()
+opts_menu.add_command(label='', command=toggle_save_prompt)
+updateSavePromptLabel()
 menu_bar.add_cascade(label='Options', menu=opts_menu)
 
 win_menu = tk.Menu(menu_bar, tearoff=0)

--- a/main.py
+++ b/main.py
@@ -2343,14 +2343,17 @@ def opcodes_list():
         opcodes_win = None
     opcodes_win = tk.Tk()
     opcodes_win.title('Opcodes list')
-    opcodes_win.geometry('650x800+50+50')
-    codes_list_box = tk.Listbox(opcodes_win, font=('Courier', 10))
+    opcodes_win.geometry('664x800+50+50')
+    scrollbar = tk.Scrollbar(opcodes_win)
+    scrollbar.pack(side=tk.RIGHT, fill=tk.Y)
+    codes_list_box = tk.Listbox(opcodes_win, font=('Courier', 10),yscrollcommand=scrollbar.set)
     [codes_list_box.insert(tk.END, i + ': ' + DOCUMENTATION[i]) for i in DOCUMENTATION]
     codes_list_box.place(x=5, y=5, width=640, height=790)
     opcodes_win.bind('<Escape>', lambda _: opcodes_win.destroy())
     change_colours()
     opcodes_win.protocol('WM_DELETE_WINDOW', opcodes_win_equals_none)
     opcodes_win.resizable(False, False)
+    scrollbar.config(command=codes_list_box.yview)
     opcodes_win.mainloop()
 
 

--- a/main.py
+++ b/main.py
@@ -2101,28 +2101,7 @@ def toggle_save_prompt():
     app_config["prompt_save_on_exit"] = not app_config["prompt_save_on_exit"]
     save_config()
     updateSavePromptLabel()
-
-def updateToggleBaseFileLabel():
-    win_menu.entryconfigure(2, label='Toggle Base Textbox (F3) {0}'.format('☑' if app_config['toggle_base_file'] else '☐'))
-
-def updateToggleStatusBarLabel():
-    win_menu.entryconfigure(3, label='Toggle Status Bar {0}'.format('☑' if app_config['status_bar'] else '☐'))
-
-def updateToggleAddressLabel(noValue = False): 
-    opts_menu.entryconfigure(6, label='Toggle "game entry point" mode (F5) {0}'.format('' if noValue else ('☑' if disasm.game_address_mode else '☐')))
-
-def updateToggleHexLabel():
-    opts_menu.entryconfigure(7, label='Toggle hex mode (F6) {0}'.format('☑' if app_config['hex_mode'] else '☐'))
-
-def updateToggleBinLabel():
-    opts_menu.entryconfigure(9, label='Toggle bin mode (F8) {0}'.format('☑' if app_config['bin_mode'] else '☐'))
-
-def updateToggleHexSpaceLabel():
-    opts_menu.entryconfigure(8, label='Toggle hex/bin space separation (F7) {0}'.format('☑' if app_config['hex_space_separation'] else '☐'))
-
-def updateSavePromptLabel():
-    opts_menu.entryconfigure(11, label='Prompt Save on Exit? {0}'.format('☑' if app_config["prompt_save_on_exit"] else '☐'))
-
+    
 def toggle_address_mode(buffering=True):
     global function_select
     if not disassembler_loaded():
@@ -4371,6 +4350,38 @@ auto_open = tk.BooleanVar()
 calc_crc = tk.BooleanVar()
 auto_open.set(app_config['open_roms_automatically'])
 
+#toggle-button state vars
+buttonStates = {}
+for i in ["baseFile","statusBar","savePrompt","address","hex","bin","hexSpace"]:
+    buttonStates[i] = tk.BooleanVar()
+
+def checkFlipStateValues(varName,configName,menu, itemNum):
+    if (buttonStates[varName].get() != app_config[configName]):
+        menu.entryconfigure(itemNum, offvalue=1, onvalue=0)
+    else:
+        menu.entryconfigure(itemNum, offvalue=0, onvalue=1)
+
+def updateToggleBaseFileLabel():
+    checkFlipStateValues("baseFile","toggle_base_file",win_menu, 2)
+    
+def updateToggleStatusBarLabel():
+    checkFlipStateValues("statusBar","status_bar",win_menu,3)
+   
+def updateToggleAddressLabel(noValue = False):
+    checkFlipStateValues("address","game_address_mode",opts_menu,6)
+
+def updateToggleHexLabel():
+    checkFlipStateValues("hex","hex_mode",opts_menu,7)
+
+def updateToggleBinLabel():
+    checkFlipStateValues("bin","bin_mode",opts_menu,9)
+
+def updateToggleHexSpaceLabel():
+    checkFlipStateValues("hexSpace","hex_space_separation",opts_menu,8)
+
+def updateSavePromptLabel():
+    checkFlipStateValues("savePrompt","prompt_save_on_exit",opts_menu,11)
+
 file_menu = tk.Menu(menu_bar, tearoff=0)
 file_menu.add_command(label='Start new', command=lambda: open_files('new'))
 file_menu.add_command(label='Open existing', command=lambda: open_files('existing'))
@@ -4415,25 +4426,25 @@ opts_menu.add_separator()
 opts_menu.add_command(label='Set memory editor offset', command=set_mem_edit_offset)
 opts_menu.add_command(label='Set memory regions', command=set_memory_regions)
 opts_menu.add_separator()
-opts_menu.add_command(label='', command=toggle_address_mode)
+opts_menu.add_checkbutton(label='Toggle "game entry point" mode (F5)', command=toggle_address_mode, variable = buttonStates["address"])
 updateToggleAddressLabel(True)
-opts_menu.add_command(label='', command=toggle_hex_mode)
+opts_menu.add_checkbutton(label='Toggle hex mode (F6)', command=toggle_hex_mode, variable = buttonStates["hex"])
 updateToggleHexLabel()
-opts_menu.add_command(label='', command=toggle_hex_space)
+opts_menu.add_checkbutton(label='Toggle hex/bin space separation (F7)', command=toggle_hex_space, variable = buttonStates["hexSpace"])
 updateToggleHexSpaceLabel()
-opts_menu.add_command(label='', command=toggle_bin_mode)
+opts_menu.add_checkbutton(label='Toggle bin mode (F8)', command=toggle_bin_mode, variable = buttonStates["bin"])
 updateToggleBinLabel()
 opts_menu.add_separator()
-opts_menu.add_command(label='', command=toggle_save_prompt)
+opts_menu.add_checkbutton(label='Prompt Save on Exit', command=toggle_save_prompt, variable = buttonStates["savePrompt"])
 updateSavePromptLabel()
 menu_bar.add_cascade(label='Options', menu=opts_menu)
 
 win_menu = tk.Menu(menu_bar, tearoff=0)
 win_menu.add_command(label='Change colour scheme', command=set_colour_scheme)
 win_menu.add_command(label='Change window dimensions', command=change_win_dimensions)
-win_menu.add_command(label='', command=toggle_base_file)
+win_menu.add_checkbutton(label='Toggle Base Textbox (F3)', command=toggle_base_file,variable = buttonStates["baseFile"])
 updateToggleBaseFileLabel()
-win_menu.add_command(label='', command=toggle_status_bar)
+win_menu.add_checkbutton(label='Toggle Status Bar', command=toggle_status_bar,variable = buttonStates["statusBar"])
 updateToggleStatusBarLabel()
 menu_bar.add_cascade(label='Window', menu=win_menu)
 

--- a/main.py
+++ b/main.py
@@ -1,4 +1,3 @@
-
 import tkinter as tk
 import tkinter.font as tkfont
 from tkinter import simpledialog, filedialog, colorchooser
@@ -197,6 +196,7 @@ max_lines = app_config['max_lines']
 main_font_size = app_config['font_size']
 navigation = 0
 
+scrollBarWidth = 14 # width that must be added to a window geometry to make sufficient room for a scrollbar
 
 def font_dimension(size):
     fonty = tkfont.Font(family='Courier', size=size, weight='normal')
@@ -2343,7 +2343,7 @@ def opcodes_list():
         opcodes_win = None
     opcodes_win = tk.Tk()
     opcodes_win.title('Opcodes list')
-    opcodes_win.geometry('664x800+50+50')
+    opcodes_win.geometry('{0}x800+50+50'.format(650+scrollBarWidth))
     scrollbar = tk.Scrollbar(opcodes_win)
     scrollbar.pack(side=tk.RIGHT, fill=tk.Y)
     codes_list_box = tk.Listbox(opcodes_win, font=('Courier', 10),yscrollcommand=scrollbar.set)
@@ -2587,9 +2587,13 @@ def view_comments():
         return
     comments_window = tk.Tk()
     comments_window.title('Comments')
-    comments_window.geometry('{}x{}'.format(comments_win_w,comments_win_h))
-    comments_list_box = tk.Listbox(comments_window, font=('Courier', main_font_size))
+    comments_window.geometry('{}x{}'.format(comments_win_w + scrollBarWidth,comments_win_h))
+    scrollbar = tk.Scrollbar(comments_window)
+    scrollbar.pack(side=tk.RIGHT, fill=tk.Y)
+    comments_list_box = tk.Listbox(comments_window, font=('Courier', main_font_size), yscrollcommand=scrollbar.set)
     comments_list_box.place(x=comments_x,y=comments_y,width=comments_w,height=comments_h)
+    scrollbar.config(command=comments_list_box.yview)
+
 
     # If this doesn't want to work the way the auto-copy checkbox does, then it will have to work by force
     def hack_checkbox_callback():
@@ -3787,8 +3791,11 @@ def find_phrase():
         phrases_win = tk.Tk()
         divide_by = (len(phrases) + 1) if len(phrases) > 1 else 1
         phrases_win.title('{} Results'.format(len(display_list) // divide_by))
-        phrases_win.geometry('400x500+50+50')
-        phrases_list_box = tk.Listbox(phrases_win, font=('Courier', 10))
+        phrases_win.geometry('{0}x500+50+50'.format(400+scrollBarWidth))
+        scrollbar = tk.Scrollbar(phrases_win)
+        scrollbar.pack(side=tk.RIGHT, fill=tk.Y)
+        phrases_list_box = tk.Listbox(phrases_win, font=('Courier', 10),yscrollcommand=scrollbar.set)
+        scrollbar.config(command=phrases_list_box.yview)
         [phrases_list_box.insert(tk.END, i) for i in display_list]
 
         def list_callback():

--- a/main.py
+++ b/main.py
@@ -183,20 +183,19 @@ def setWindowScrollbar(scrollType, a, b=None):
         #determine how much we need to scroll to meet the scrollbar position
         amount_words = disasm.file_length >> 2
         firstLine = navigation
-        midLine = navigation + app_config["max_lines"]//2
-        lastLine = navigation + app_config["max_lines"]
         scrolledLine = float(a)*int(amount_words)
-        print(scrolledLine)
-        evnt.delta = -1 if scrolledLine < midLine else 1
-        scrollTicks = int(abs(scrolledLine - midLine) // app_config['scroll_amount'])
-        print('ticks:',scrollTicks)
+        evnt.delta = -1 if scrolledLine < firstLine else 1
+        
+        scrollTicks = int(abs(scrolledLine - firstLine) // app_config['scroll_amount'])
         if (scrollTicks != 0):
+            if (abs(scrollTicks) < 1):
+                scrollTicks = 1 if scrollTicks > 0 else -1
             scroll_callback(evnt,-scrollTicks)
 
 def updateWindowScrollbarPos():
     amount_words = disasm.file_length >> 2
-    lastLine = navigation + app_config["max_lines"]
     firstLine = navigation
+    lastLine = navigation + app_config["max_lines"]
     windowScrollbar.set(firstLine/amount_words,lastLine/amount_words)
 
 windowScrollbar = tk.Scrollbar(window)
@@ -1608,6 +1607,7 @@ def navigate_to(index, center=False, widget=None, region_treatment=False, region
 
     highlight_stuff(widget, skip_moving_cursor=center)
 
+    updateWindowScrollbarPos()
 
 def navigation_callback(address):
     widget = check_widget(window.focus_get())
@@ -1647,8 +1647,6 @@ def scroll_callback(event,numUnits=1):
     apply_comment_changes()
     direction = -app_config['scroll_amount'] if event.delta > 0 else app_config['scroll_amount']
     navigate_to(navigation + direction * numUnits, widget=check_widget(window.focus_get()))
-    updateWindowScrollbarPos()
-
 
 def save_changes_to_file(save_as=False):
     if not disassembler_loaded():

--- a/main.py
+++ b/main.py
@@ -2102,6 +2102,12 @@ def toggle_save_prompt():
     save_config()
     updateSavePromptLabel()
 
+def updateToggleBaseFileLabel():
+    win_menu.entryconfigure(2, label='Toggle Base Textbox (F3) {0}'.format('☑' if app_config['toggle_base_file'] else '☐'))
+
+def updateToggleStatusBarLabel():
+    win_menu.entryconfigure(3, label='Toggle Status Bar {0}'.format('☑' if app_config['status_bar'] else '☐'))
+
 def updateToggleAddressLabel(noValue = False): 
     opts_menu.entryconfigure(6, label='Toggle "game entry point" mode (F5) {0}'.format('' if noValue else ('☑' if disasm.game_address_mode else '☐')))
 
@@ -3090,6 +3096,7 @@ def toggle_base_file():
     apply_hack_changes()
     navigate_to(navigation)
     save_config()
+    updateToggleBaseFileLabel()
     set_widget_sizes()
 
 
@@ -3191,6 +3198,7 @@ def set_widget_sizes(new_size=0, new_max_lines=0):
 def toggle_status_bar():
     app_config['status_bar'] = not app_config['status_bar']
     save_config()
+    updateToggleStatusBarLabel()
     if app_config['status_bar']:
         status_bar.pack(side=tk.BOTTOM, fill=tk.X, padx=5, pady=3)
     else:
@@ -4423,8 +4431,10 @@ menu_bar.add_cascade(label='Options', menu=opts_menu)
 win_menu = tk.Menu(menu_bar, tearoff=0)
 win_menu.add_command(label='Change colour scheme', command=set_colour_scheme)
 win_menu.add_command(label='Change window dimensions', command=change_win_dimensions)
-win_menu.add_command(label='Toggle Base Textbox (F3)', command=toggle_base_file)
-win_menu.add_command(label='Toggle Status Bar', command=toggle_status_bar)
+win_menu.add_command(label='', command=toggle_base_file)
+updateToggleBaseFileLabel()
+win_menu.add_command(label='', command=toggle_status_bar)
+updateToggleStatusBarLabel()
 menu_bar.add_cascade(label='Window', menu=win_menu)
 
 help_menu = tk.Menu(menu_bar,tearoff=0)

--- a/main.py
+++ b/main.py
@@ -4355,32 +4355,29 @@ buttonStates = {}
 for i in ["baseFile","statusBar","savePrompt","address","hex","bin","hexSpace"]:
     buttonStates[i] = tk.BooleanVar()
 
-def checkFlipStateValues(varName,configName,menu, itemNum):
-    if (buttonStates[varName].get() != app_config[configName]):
-        menu.entryconfigure(itemNum, offvalue=1, onvalue=0)
-    else:
-        menu.entryconfigure(itemNum, offvalue=0, onvalue=1)
-
 def updateToggleBaseFileLabel():
-    checkFlipStateValues("baseFile","toggle_base_file",win_menu, 2)
+    buttonStates["baseFile"].set(app_config["toggle_base_file"])
     
 def updateToggleStatusBarLabel():
-    checkFlipStateValues("statusBar","status_bar",win_menu,3)
-   
+    buttonStates["statusBar"].set(app_config["status_bar"])
+    
 def updateToggleAddressLabel(noValue = False):
-    checkFlipStateValues("address","game_address_mode",opts_menu,6)
-
+    if (noValue):
+        buttonStates["address"].set(next (iter (app_config["game_address_mode"].values())))
+    else:
+         buttonStates["address"].set(disasm.game_address_mode)
+    
 def updateToggleHexLabel():
-    checkFlipStateValues("hex","hex_mode",opts_menu,7)
-
+    buttonStates["hex"].set(app_config["hex_mode"])
+    
 def updateToggleBinLabel():
-    checkFlipStateValues("bin","bin_mode",opts_menu,9)
-
+    buttonStates["bin"].set(app_config["bin_mode"])
+    
 def updateToggleHexSpaceLabel():
-    checkFlipStateValues("hexSpace","hex_space_separation",opts_menu,8)
-
+    buttonStates["hexSpace"].set(app_config["hex_space_separation"])
+    
 def updateSavePromptLabel():
-    checkFlipStateValues("savePrompt","prompt_save_on_exit",opts_menu,11)
+    buttonStates["savePrompt"].set(app_config["prompt_save_on_exit"])
 
 file_menu = tk.Menu(menu_bar, tearoff=0)
 file_menu.add_command(label='Start new', command=lambda: open_files('new'))


### PR DESCRIPTION
Adds scrollbars to main, opcodes, comments, changes, and phrases windows, allowing the user to navigate these windows via the scrollbar. Adds checkboxes to game entry point, hex mode, hex/bin separation, bin mode, base textbox, and status bar options. Adds option to disable save prompt on exit.